### PR TITLE
Fix FAISS path handling

### DIFF
--- a/faiss_search.py
+++ b/faiss_search.py
@@ -1,13 +1,15 @@
 # faiss_search.py
 import faiss, pandas as pd, numpy as np
 from sentence_transformers import SentenceTransformer
+from pathlib import Path
 
-INDEX_PATH = "horizon_scanning.faiss"
-META_PATH  = "horizon_scanning_meta.parquet"
+BASE_DIR = Path(__file__).resolve().parent
+INDEX_PATH = BASE_DIR / "horizon_scanning.faiss"
+META_PATH  = BASE_DIR / "horizon_scanning_meta.parquet"
 EMBED_MODEL_NAME = "all-MiniLM-L6-v2"          # must match the scraper
 
 # --- load once at import ----------------------------------------
-index = faiss.read_index(INDEX_PATH)
+index = faiss.read_index(str(INDEX_PATH))
 meta  = pd.read_parquet(META_PATH).set_index("id")   # id column = index
 embed = SentenceTransformer(EMBED_MODEL_NAME)
 

--- a/retrieval_backend.py
+++ b/retrieval_backend.py
@@ -5,14 +5,15 @@ import json
 from sentence_transformers import SentenceTransformer
 from pathlib import Path
 
-_VECTORS = "horizon_scanning.faiss"
-_META    = "horizon_scanning_meta.parquet"
+BASE_DIR = Path(__file__).resolve().parent
+_VECTORS = BASE_DIR / "horizon_scanning.faiss"
+_META    = BASE_DIR / "horizon_scanning_meta.parquet"
 _EMBED_MODEL = SentenceTransformer("all-MiniLM-L6-v2", device="cpu")
 
 def ready() -> bool:
-    return (Path(_VECTORS).exists() and Path(_META).exists())
+    return (_VECTORS.exists() and _META.exists())
 
-index = faiss.read_index(_VECTORS) if ready() else None
+index = faiss.read_index(str(_VECTORS)) if ready() else None
 meta  = (pd.read_parquet(_META)
          .set_index("id")            # id column we added in STEP 9b
          if ready() else None)


### PR DESCRIPTION
## Summary
- load FAISS index and metadata relative to module location

## Testing
- `python -m py_compile *.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_6853e6a8f1b8832cb9f68407f41dc3f9