### PR TITLE
Fix README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ stores semantic embeddings, and answers policy questions with an LLM**
 ├── requirements.txt
 └── .gitignore
 
-````
+```
 
 > **Large runtime artefacts** (`*.faiss`, `*.parquet`, `horizon_scanning_combined.csv`) are ignored by Git via `.gitignore`.
 
@@ -53,7 +53,7 @@ cd horizon-scanning-agent
 pip install -r requirements.txt
 
 # 3. add your secrets
-cp .env.example .env            # then edit
+# create a .env file with
 #   OPENAI_API_KEY=...
 #   SCOPUS_API_KEY=...(optional)
 
@@ -62,7 +62,7 @@ python policy_signal_scanner_v3.py
 
 # 5. chat with the agent
 python agent_app.py
-````
+```
 
 ---
 
@@ -103,5 +103,4 @@ MIT – see `LICENSE`.
 
 Dal Borgo R. (2025) Horizon-Scanning Agent, v0.1.*
 
-```
 ```

--- a/policy_signal_scanner_v3.py
+++ b/policy_signal_scanner_v3.py
@@ -145,8 +145,12 @@ logging.info("All async sources fetched.")
 def load_cordis_projects(filepath="cordis-h2020projects.json", max_results=20):
     logging.info("Loading CORDIS Horizon 2020 projects …")
 
-    with open(filepath, encoding="utf-8") as f:
-        data = json.load(f)
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        logging.warning("CORDIS dataset %s not found; skipping.", filepath)
+        return pd.DataFrame()
 
     selected = []
     for rec in data:

--- a/test_query.py
+++ b/test_query.py
@@ -1,8 +1,38 @@
+"""Sanity test for the ``search`` helper.
+
+This file serves two purposes:
+
+* When executed via ``pytest`` it defines ``test_search`` which verifies that
+  the retrieval backend returns at least one result and contains the expected
+  columns.
+* When run directly (``python test_query.py``) it prints a nicely formatted
+  preview table of the top five search hits.
+"""
+
 from faiss_search import search
 
-df = search("impact of labour mobility on EU policy", k=5)
+EXPECTED_COLS = {"title", "source_name", "recency_label", "pestle_tags", "distance"}
 
-# show a few useful columns
-print(df[["title", "source_name", "recency_label", "pestle_tags", "distance"]]
-        .to_markdown(index=False, tablefmt="github"))
+
+def test_search() -> None:
+    """Basic functional test for the ``search`` helper."""
+    df = search("impact of labour mobility on EU policy", k=5)
+    assert not df.empty, "search() returned no results"
+    assert EXPECTED_COLS.issubset(df.columns)
+
+
+if __name__ == "__main__":
+    import sys
+    from tabulate import tabulate
+
+    query = sys.argv[1] if len(sys.argv) > 1 else "impact of labour mobility on EU policy"
+    df = search(query, k=5)
+    preview = df[[
+        "title",
+        "source_name",
+        "recency_label",
+        "pestle_tags",
+        "distance",
+    ]].head(5)
+    print(tabulate(preview, headers="keys", tablefmt="github", showindex=False))
 


### PR DESCRIPTION
## Summary
- fix Markdown blocks in README and update .env instructions
- handle missing CORDIS dataset gracefully
- convert test_query script into a pytest test
- add CLI preview when running test_query.py directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_6853e6a8e950832caa1b78ea5081a76d